### PR TITLE
update webassets to 0.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ pytz==2014.10
 requests==2.6.0
 six==1.9.0
 tablib==0.10.0
-webassets==0.10.1
+webassets==0.12.1
 wsgiref==0.1.2


### PR DESCRIPTION
This is needed to fix a problem where `ASSETS_URL` would always only return an empty string when the wrong combination of `webassets`/`jinja` got installed. 

More information here: https://github.com/miracle2k/webassets/issues/477